### PR TITLE
[fix] Sidebar Light-Mode & Mobile Rendering

### DIFF
--- a/src/components/MobileMenuButton.jsx
+++ b/src/components/MobileMenuButton.jsx
@@ -5,13 +5,13 @@ const MobileMenuButton = ({ isOpen, onToggle }) => {
   return (
     <button
       onClick={onToggle}
-      className="md:hidden fixed top-4 left-4 z-[110] p-2 rounded-lg bg-card border border-border shadow-lg hover:bg-accent transition-colors"
+      className="md:hidden fixed top-4 left-4 z-[60] p-2 rounded-lg bg-white dark:bg-slate-900 border border-gray-200 dark:border-gray-700 shadow-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
       aria-label={isOpen ? 'Menü schließen' : 'Menü öffnen'}
     >
       {isOpen ? (
-        <X className="w-6 h-6 text-card-foreground" />
+        <X className="w-6 h-6 text-black dark:text-white" />
       ) : (
-        <Menu className="w-6 h-6 text-card-foreground" />
+        <Menu className="w-6 h-6 text-black dark:text-white" />
       )}
     </button>
   );

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -72,7 +72,7 @@ const MainLayout = () => {
       {/* Mobile Overlay */}
       {mobileMenuOpen && (
         <div 
-          className="fixed inset-0 bg-black bg-opacity-50 z-[90] md:hidden"
+          className="fixed inset-0 bg-black bg-opacity-50 z-[40] md:hidden"
           onClick={() => handleMobileMenuToggle(false)}
         />
       )}

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -223,21 +223,22 @@ const Sidebar = ({ isCollapsed, onToggle, theme, onThemeToggle, isMobileOpen, on
       {/* Mobile Sidebar */}
       <div className={`
         fixed left-0 top-0 h-full 
-        bg-background dark:bg-card border-r border-border
-        transition-transform duration-300 ease-in-out shadow-xl
-        w-64 z-[100]
+        bg-white dark:bg-slate-900 text-black dark:text-white
+        border-r border-gray-200 dark:border-gray-700
+        transition-transform duration-300 ease-in-out shadow-lg backdrop-blur-md
+        w-72 z-50
         md:hidden
         ${isMobileOpen ? 'translate-x-0' : '-translate-x-full'}
       `}>
         {/* Mobile Header */}
-        <div className="flex items-center justify-between p-4 border-b border-border">
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center gap-3">
             <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center">
               <span className="text-white font-bold text-sm">C</span>
             </div>
             <div>
-              <h1 className="font-bold text-foreground dark:text-card-foreground">Clara360</h1>
-              <p className="text-xs text-muted-foreground">Fusion Dashboard</p>
+              <h1 className="font-bold text-black dark:text-white">Clara360</h1>
+              <p className="text-xs text-gray-600 dark:text-gray-400">Fusion Dashboard</p>
             </div>
           </div>
         </div>
@@ -257,23 +258,23 @@ const Sidebar = ({ isCollapsed, onToggle, theme, onThemeToggle, isMobileOpen, on
                     w-full flex items-center gap-3 px-3 py-2.5 rounded-lg
                     transition-all duration-200 text-left group
                     ${active 
-                      ? 'bg-primary text-primary-foreground' 
-                      : 'text-foreground dark:text-card-foreground hover:bg-accent hover:text-accent-foreground'
+                      ? 'bg-blue-600 text-white' 
+                      : 'text-black dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800'
                     }
                   `}
                 >
                   <Icon className={`
                     w-5 h-5 flex-shrink-0
-                    ${active ? 'text-primary-foreground' : 'text-muted-foreground group-hover:text-accent-foreground'}
+                    ${active ? 'text-white' : 'text-gray-600 dark:text-gray-400 group-hover:text-black dark:group-hover:text-white'}
                   `} />
                   
                   <div className="flex-1 min-w-0">
                     <div className="font-medium text-sm">{item.label}</div>
-                    <div className="text-xs text-muted-foreground truncate">{item.description}</div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400 truncate">{item.description}</div>
                   </div>
                   
                   {active && (
-                    <div className="w-2 h-2 bg-primary-foreground rounded-full flex-shrink-0"></div>
+                    <div className="w-2 h-2 bg-white rounded-full flex-shrink-0"></div>
                   )}
                 </button>
               );
@@ -282,13 +283,13 @@ const Sidebar = ({ isCollapsed, onToggle, theme, onThemeToggle, isMobileOpen, on
         </nav>
 
         {/* Mobile Theme Toggle */}
-        <div className="p-4 border-t border-border">
+        <div className="p-4 border-t border-gray-200 dark:border-gray-700">
           <button
             onClick={onThemeToggle}
-            className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-foreground dark:text-card-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+            className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-black dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
           >
             {theme === 'light' ? (
-              <Moon className="w-5 h-5 text-muted-foreground" />
+              <Moon className="w-5 h-5 text-gray-600 dark:text-gray-400" />
             ) : (
               <Sun className="w-5 h-5 text-yellow-500" />
             )}
@@ -304,7 +305,7 @@ const Sidebar = ({ isCollapsed, onToggle, theme, onThemeToggle, isMobileOpen, on
           </button>
           
           <div className="mt-4">
-            <div className="text-xs text-muted-foreground text-center">
+            <div className="text-xs text-gray-500 dark:text-gray-400 text-center">
               Immobilien-Management
             </div>
           </div>


### PR DESCRIPTION
- Mobile Sidebar: bg-white dark:bg-slate-900 für korrekte Hintergrundfarben
- Text-Farben: text-black dark:text-white für optimale Lesbarkeit
- Navigation: hover:bg-gray-100 dark:hover:bg-gray-800 für bessere UX
- Icons: text-gray-600 dark:text-gray-400 für konsistente Darstellung
- Z-Index-Hierarchie: z-50 Sidebar, z-[60] Button, z-[40] Overlay
- Border: border-gray-200 dark:border-gray-700 für saubere Abgrenzung
- Mobile-optimiert: w-72 h-full shadow-lg backdrop-blur-md

Fixes: Schwarze Sidebar im Light-Mode auf mobilen Geräten
Validiert: Samsung Galaxy & Chrome Mobile

## 🧾 Was wurde geändert?

## 🔍 Wie wurde getestet?

## 🧪 Automatisierte Checks bestanden?
- [ ] Lint erfolgreich (`npm run lint`)
- [ ] Tests erfolgreich (`npm run test`)
- [ ] CI Build durchgelaufen (GitHub Actions)

## 🧩 Reviewer-Hinweise

---
*PR Template erstellt: 2025-06-26_11-35-10*
