### PR TITLE
[fix] Light-Mode Hintergrundfarben korrigiert - weiße Sidebar und hel…

### DIFF
--- a/src/components/ClaraKIPanel.jsx
+++ b/src/components/ClaraKIPanel.jsx
@@ -109,7 +109,7 @@ const ClaraKIPanel = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-slate-900">
+    <div className="min-h-screen bg-white dark:bg-slate-900">
       <main className="flex-1 p-4 md:p-6 md:ml-16 lg:ml-64">
         {/* Header */}
         <div className="mb-6">

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -40,7 +40,7 @@ const MainLayout = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-white dark:bg-slate-900 text-black dark:text-white">
       {/* Mobile Menu Button */}
       <MobileMenuButton 
         isOpen={mobileMenuOpen}

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -5,7 +5,7 @@ const Card = React.forwardRef(({ className, ...props }, ref) => (
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border bg-white dark:bg-slate-800 text-black dark:text-white shadow-sm border-gray-200 dark:border-gray-700",
       className
     )}
     {...props}
@@ -37,7 +37,7 @@ CardTitle.displayName = "CardTitle"
 const CardDescription = React.forwardRef(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-sm text-gray-600 dark:text-gray-400", className)}
     {...props}
   />
 ))


### PR DESCRIPTION
…ler Content

- ClaraKIPanel: bg-gray-50 → bg-white für Light-Mode Hintergrund
- MainLayout: bg-background → bg-white dark:bg-slate-900 für konsistente Farben
- Card-Komponente: bg-card → bg-white dark:bg-slate-800 für korrekte Card-Hintergründe
  - Border: border-gray-200 dark:border-gray-700 für bessere Abgrenzung
  - Text: text-black dark:text-white für optimale Lesbarkeit
- CardDescription: text-muted-foreground → text-gray-600 dark:text-gray-400

Fixes: Light-Mode zeigt jetzt weißen Hintergrund statt dunklen Sidebar: Bleibt weiß im Light-Mode, dunkel im Dark-Mode Content: Weißer Hintergrund im Light-Mode, dunkler im Dark-Mode ClaraContext v6.2.6

## 🧾 Was wurde geändert?

## 🔍 Wie wurde getestet?

## 🧪 Automatisierte Checks bestanden?
- [ ] Lint erfolgreich (`npm run lint`)
- [ ] Tests erfolgreich (`npm run test`)
- [ ] CI Build durchgelaufen (GitHub Actions)

## 🧩 Reviewer-Hinweise

---
*PR Template erstellt: 2025-06-26_11-35-10*
